### PR TITLE
Do not crash on other signals (e.g. sighup)

### DIFF
--- a/lib/graceful_stop/handler.ex
+++ b/lib/graceful_stop/handler.ex
@@ -51,9 +51,14 @@ defmodule GracefulStop.Handler do
     {:ok, state |> set_status(:stopping)}
   end
 
+  def handle_event(_signal, state) do
+    {:ok, state}
+  end
+
   def handle_info(:resume, state) do
     {:ok, state |> set_status(:running)}
   end
+
   def handle_info(_message, state) do
     # Logger.info "handle_info: #{inspect message}"
     {:ok, state}


### PR DESCRIPTION
We use sighup signal for our internal needs. We found that `graceful_stop` may crash if it traps `:sighup` signal.

This fix should prevent crashing.

![Screenshot 2024-04-09 at 19 16 19](https://github.com/botsquad/graceful_stop/assets/378207/47df2e09-6673-47c1-9fe4-efc43f1da18d)
